### PR TITLE
Aa eu compute next purchase date

### DIFF
--- a/src/components/AddItem.js
+++ b/src/components/AddItem.js
@@ -67,6 +67,8 @@ const AddItem = () => {
       itemName,
       nextPurchase,
       lastPurchase,
+      estimatedPurchaseInterval: null,
+      totalPurchases: 0,
     };
 
     if (tokenList.includes(currToken)) {

--- a/src/components/ListItem.js
+++ b/src/components/ListItem.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { db } from '../lib/firebase.js';
+import { calculateEstimate } from '@the-collab-lab/shopping-list-utils';
 import { NavLink } from 'react-router-dom';
 import { collection, doc, onSnapshot, updateDoc } from 'firebase/firestore';
 import Footer from './Footer';
@@ -58,6 +59,17 @@ const ListItem = () => {
     for (let item of items) {
       if (item.itemName === itemName) {
         item.lastPurchase = Date.now();
+        const daysSinceLastTransaction = item.lastPurchasedDate
+          ? Math.round(
+              (Date.now() - item.lastPurchasedDate) / 1000 / 60 / 60 / 24,
+            )
+          : 0;
+        item.estimatedPurchaseInterval = calculateEstimate(
+          item.estimatedPurchaseInterval,
+          daysSinceLastTransaction,
+          item.totalPurchases,
+        );
+        item.totalPurchases = item.totalPurchases + 1;
         updateDoc(currentCollectionRef, { items: items });
       }
     }

--- a/src/components/ListItem.js
+++ b/src/components/ListItem.js
@@ -58,17 +58,15 @@ const ListItem = () => {
   const handleOnChange = (itemName) => {
     for (let item of items) {
       if (item.itemName === itemName) {
-        item.lastPurchase = Date.now();
-        const daysSinceLastTransaction = item.lastPurchasedDate
-          ? Math.round(
-              (Date.now() - item.lastPurchasedDate) / 1000 / 60 / 60 / 24,
-            )
+        const daysSinceLastTransaction = item.lastPurchase
+          ? Math.round((Date.now() - item.lastPurchase) / 1000 / 60 / 60 / 24)
           : 0;
         item.estimatedPurchaseInterval = calculateEstimate(
           item.estimatedPurchaseInterval,
           daysSinceLastTransaction,
           item.totalPurchases,
         );
+        item.lastPurchase = Date.now();
         item.totalPurchases = item.totalPurchases + 1;
         updateDoc(currentCollectionRef, { items: items });
       }
@@ -92,7 +90,7 @@ const ListItem = () => {
                   <input
                     type="checkbox"
                     id={item.itemName}
-                    disabled={handlePurchaseInLastDay(item.lastPurchase)}
+                    // disabled={handlePurchaseInLastDay(item.lastPurchase)}
                     checked={handlePurchaseInLastDay(item.lastPurchase)}
                     onChange={() => handleOnChange(item.itemName)}
                   />

--- a/src/components/ListItem.js
+++ b/src/components/ListItem.js
@@ -90,7 +90,7 @@ const ListItem = () => {
                   <input
                     type="checkbox"
                     id={item.itemName}
-                    // disabled={handlePurchaseInLastDay(item.lastPurchase)}
+                    disabled={handlePurchaseInLastDay(item.lastPurchase)}
                     checked={handlePurchaseInLastDay(item.lastPurchase)}
                     onChange={() => handleOnChange(item.itemName)}
                   />


### PR DESCRIPTION
## Description

This PR adds functionality to calculate the estimation of the number of days until the next purchase date and record it in the database.

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->

## Related Issue

Closes #10 

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->

## Acceptance Criteria

- When a purchase is recorded, the estimated number of days until the next purchase date should be calculated and recorded in the database.

<!-- Include AC from the Github issue -->

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|    | :bug: Bug fix              |
|  ✓ | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before

<!-- If UI feature, take provide screenshots -->


### After

<!-- If UI feature, take provide screenshots -->


## Testing Steps / QA Criteria

- Pull the branch.
- Run `npm start`
- Launch the browser to preview at http://localhost:3000/
- Click the "create a new list" button
- Click the "add item" button
- Add an item, select how soon to buy the item, click the "Add Item" button.
- Navigate to the List page and open `developer's tool > the Application tab` to see the generated three words token.
- Go to Firebase and open the document with the generated three words token as you see on the Application tab.
  Here you will see new fields of `estimatedPurchaseInterval: null` and `totalPurchase: 0`.
- Check the item on the List page and get back to the Firebase.
  The expected behavior is `totalPurchase` will be added by 1.
- Subtract the `lastPurchase` to uncheck the checklist.
- Go to the List and check the item again.
- Go back to Firebase.
  Now you should see that the `totalPurchase` is updated and `estimatedPurchaseInterval` starts estimating days of the next purchase and gets recorded in the database.

<!-- Provide steps the other cohort members and mentors need to follow to properly test your additions. -->

